### PR TITLE
YQ 2837.memory

### DIFF
--- a/app/server/paging/columnar_buffer_arrow_ipc_streaming_default.go
+++ b/app/server/paging/columnar_buffer_arrow_ipc_streaming_default.go
@@ -41,6 +41,7 @@ func (cb *columnarBufferArrowIPCStreamingDefault[T]) addRow(transformer RowTrans
 
 // ToResponse returns all the accumulated data and clears buffer
 func (cb *columnarBufferArrowIPCStreamingDefault[T]) ToResponse() (*api_service_protos.TReadSplitsResponse, error) {
+	// chunk consists of columns
 	chunk := make([]arrow.Array, 0, len(cb.builders))
 
 	// prepare arrow record

--- a/common/arrow_helpers.go
+++ b/common/arrow_helpers.go
@@ -150,10 +150,12 @@ func ydbTypeToArrowBuilder(typeID Ydb.Type_PrimitiveTypeId, arrowAllocator memor
 		builder = array.NewFloat64Builder(arrowAllocator)
 	case Ydb.Type_STRING:
 		builder = array.NewBinaryBuilder(arrowAllocator, arrow.BinaryTypes.Binary)
+		builder.(*array.BinaryBuilder).ReserveData(1 << 20)
 	case Ydb.Type_UTF8:
 		// TODO: what about LargeString?
 		// https://arrow.apache.org/docs/cpp/api/datatype.html#_CPPv4N5arrow4Type4type12LARGE_STRINGE
 		builder = array.NewStringBuilder(arrowAllocator)
+		builder.(*array.StringBuilder).ReserveData(1 << 20)
 	case Ydb.Type_DATE:
 		builder = array.NewUint16Builder(arrowAllocator)
 	case Ydb.Type_DATETIME:
@@ -163,6 +165,8 @@ func ydbTypeToArrowBuilder(typeID Ydb.Type_PrimitiveTypeId, arrowAllocator memor
 	default:
 		return nil, fmt.Errorf("register type '%v': %w", typeID, ErrDataTypeNotSupported)
 	}
+
+	builder.Reserve(1 << 10)
 
 	return builder, nil
 }

--- a/common/arrow_helpers.go
+++ b/common/arrow_helpers.go
@@ -150,11 +150,13 @@ func ydbTypeToArrowBuilder(typeID Ydb.Type_PrimitiveTypeId, arrowAllocator memor
 		builder = array.NewFloat64Builder(arrowAllocator)
 	case Ydb.Type_STRING:
 		builder = array.NewBinaryBuilder(arrowAllocator, arrow.BinaryTypes.Binary)
+		// TODO: find more reasonable constant, maybe make dependency on paging settings
 		builder.(*array.BinaryBuilder).ReserveData(1 << 20)
 	case Ydb.Type_UTF8:
 		// TODO: what about LargeString?
 		// https://arrow.apache.org/docs/cpp/api/datatype.html#_CPPv4N5arrow4Type4type12LARGE_STRINGE
 		builder = array.NewStringBuilder(arrowAllocator)
+		// TODO: find more reasonable constant, maybe make dependency on paging settings
 		builder.(*array.StringBuilder).ReserveData(1 << 20)
 	case Ydb.Type_DATE:
 		builder = array.NewUint16Builder(arrowAllocator)
@@ -166,7 +168,8 @@ func ydbTypeToArrowBuilder(typeID Ydb.Type_PrimitiveTypeId, arrowAllocator memor
 		return nil, fmt.Errorf("register type '%v': %w", typeID, ErrDataTypeNotSupported)
 	}
 
-	builder.Reserve(1 << 10)
+	// TODO: find more reasonable constant, maybe make dependency on paging settings
+	builder.Reserve(1 << 15)
 
 	return builder, nil
 }


### PR DESCRIPTION
- Preallocate arrow builders
- Avoid using reflection for traffic estimation
