### PR TITLE
fix: enable pushdown expressions in MySQL datasource

### DIFF
--- a/app/server/datasource/rdbms/mysql/sql_formatter.go
+++ b/app/server/datasource/rdbms/mysql/sql_formatter.go
@@ -1,6 +1,8 @@
 package mysql
 
 import (
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+
 	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
 	rdbms_utils "github.com/ydb-platform/fq-connector-go/app/server/datasource/rdbms/utils"
 )
@@ -10,8 +12,59 @@ var _ rdbms_utils.SQLFormatter = (*sqlFormatter)(nil)
 type sqlFormatter struct {
 }
 
-func (sqlFormatter) SupportsPushdownExpression(_ *api_service_protos.TExpression) bool {
-	return false
+func (sqlFormatter) supportsType(typeID Ydb.Type_PrimitiveTypeId) bool {
+	switch typeID {
+	case Ydb.Type_BOOL:
+		return true
+	case Ydb.Type_INT8:
+		return true
+	case Ydb.Type_UINT8:
+		return true
+	case Ydb.Type_INT16:
+		return true
+	case Ydb.Type_UINT16:
+		return true
+	case Ydb.Type_INT32:
+		return true
+	case Ydb.Type_UINT32:
+		return true
+	case Ydb.Type_INT64:
+		return true
+	case Ydb.Type_UINT64:
+		return true
+	case Ydb.Type_FLOAT:
+		return true
+	case Ydb.Type_DOUBLE:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f sqlFormatter) supportsConstantValueExpression(t *Ydb.Type) bool {
+	switch v := t.Type.(type) {
+	case *Ydb.Type_TypeId:
+		return f.supportsType(v.TypeId)
+	case *Ydb.Type_OptionalType:
+		return f.supportsConstantValueExpression(v.OptionalType.Item)
+	default:
+		return false
+	}
+}
+
+func (f sqlFormatter) SupportsPushdownExpression(expression *api_service_protos.TExpression) bool {
+	switch e := expression.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		return true
+	case *api_service_protos.TExpression_TypedValue:
+		return f.supportsConstantValueExpression(e.TypedValue.Type)
+	case *api_service_protos.TExpression_ArithmeticalExpression:
+		return false
+	case *api_service_protos.TExpression_Null:
+		return true
+	default:
+		return false
+	}
 }
 
 func (sqlFormatter) GetPlaceholder(_ int) string {

--- a/tests/infra/datasource/mysql/init/02_pushdown.sql
+++ b/tests/infra/datasource/mysql/init/02_pushdown.sql
@@ -1,0 +1,11 @@
+CREATE TABLE pushdown (
+    id INT NOT NULL,
+    int_column INT,
+    varchar_column VARCHAR(255)
+);
+
+INSERT INTO pushdown (id, int_column, varchar_column) VALUES
+(1, 10, 'a'),
+(2, 20, 'b'),
+(3, 30, 'c'),
+(4, NULL, NULL);

--- a/tests/infra/datasource/mysql/suite.go
+++ b/tests/infra/datasource/mysql/suite.go
@@ -2,8 +2,13 @@ package mysql
 
 import (
 	api_common "github.com/ydb-platform/fq-connector-go/api/common"
+	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
+	tests_utils "github.com/ydb-platform/fq-connector-go/tests/utils"
+
+	"github.com/ydb-platform/fq-connector-go/common"
 	"github.com/ydb-platform/fq-connector-go/tests/infra/datasource"
 	"github.com/ydb-platform/fq-connector-go/tests/suite"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 )
 
 type Suite struct {
@@ -43,6 +48,196 @@ func (s *Suite) TestMissingDataSource() {
 	}
 
 	suite.TestMissingDataSource(s.Base, dsi)
+}
+
+func (s *Suite) TestPushdownComparisonL() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_L"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"int_column",
+				api_service_protos.TPredicate_TComparison_L,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(20)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonLE() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_LE"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"int_column",
+				api_service_protos.TPredicate_TComparison_LE,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(20)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonEQ() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_EQ"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"int_column",
+				api_service_protos.TPredicate_TComparison_EQ,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(20)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonGE() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_GE"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"int_column",
+				api_service_protos.TPredicate_TComparison_GE,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(20)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonG() {
+	// WHERE int_column > id
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_G"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Comparison{
+				Comparison: &api_service_protos.TPredicate_TComparison{
+					LeftValue: &api_service_protos.TExpression{
+						Payload: &api_service_protos.TExpression_Column{
+							Column: "int_column",
+						},
+					},
+					Operation: api_service_protos.TPredicate_TComparison_G,
+					RightValue: &api_service_protos.TExpression{
+						Payload: &api_service_protos.TExpression_Column{
+							Column: "id",
+						},
+					},
+				},
+			},
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonNE() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_NE"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"id",
+				api_service_protos.TPredicate_TComparison_NE,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(1)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonNULL() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_NULL"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateIsNullColumn(
+				"int_column",
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownComparisonNotNULL() {
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_comparison_NOT_NULL"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateIsNotNullColumn(
+				"int_column",
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownConjunction() {
+	// WHERE col_01_int > 10 AND col_02_string IS NOT NULL
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_conjunction"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Conjunction{
+				Conjunction: &api_service_protos.TPredicate_TConjunction{
+					Operands: []*api_service_protos.TPredicate{
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"int_column",
+								api_service_protos.TPredicate_TComparison_G,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(10)),
+							),
+						},
+						{
+							Payload: tests_utils.MakePredicateIsNotNullColumn("varchar_column"),
+						},
+					},
+				},
+			},
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownDisjunction() {
+	// WHERE col_01_int > 10 OR col_02_string IS NOT NULL
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_disjunction"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Disjunction{
+				Disjunction: &api_service_protos.TPredicate_TDisjunction{
+					Operands: []*api_service_protos.TPredicate{
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"int_column",
+								api_service_protos.TPredicate_TComparison_G,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(10)),
+							),
+						},
+						{
+							Payload: tests_utils.MakePredicateIsNotNullColumn("varchar_column"),
+						},
+					},
+				},
+			},
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownNegation() {
+	// WHERE NOT (col_01_int IS NOT NULL)
+	s.ValidateTable(
+		s.dataSource,
+		tables["pushdown_negation"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Negation{
+				Negation: &api_service_protos.TPredicate_TNegation{
+					Operand: &api_service_protos.TPredicate{
+						Payload: tests_utils.MakePredicateIsNotNullColumn(
+							"int_column",
+						),
+					},
+				},
+			},
+		}),
+	)
 }
 
 // TODO: fix error mapping in `common/errors.go`

--- a/tests/infra/datasource/mysql/suite.go
+++ b/tests/infra/datasource/mysql/suite.go
@@ -5,10 +5,11 @@ import (
 	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
 	tests_utils "github.com/ydb-platform/fq-connector-go/tests/utils"
 
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+
 	"github.com/ydb-platform/fq-connector-go/common"
 	"github.com/ydb-platform/fq-connector-go/tests/infra/datasource"
 	"github.com/ydb-platform/fq-connector-go/tests/suite"
-	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 )
 
 type Suite struct {

--- a/tests/infra/datasource/mysql/tables.go
+++ b/tests/infra/datasource/mysql/tables.go
@@ -82,4 +82,158 @@ var tables = map[string]*test_utils.Table{
 			},
 		},
 	},
+
+	"pushdown_comparison_L": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(1)},
+					"int_column":     []*int32{ptr.Int32(10)},
+					"varchar_column": []*string{ptr.T("a")},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_LE": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(1), ptr.Int32(2)},
+					"int_column":     []*int32{ptr.Int32(10), ptr.Int32(20)},
+					"varchar_column": []*string{ptr.T("a"), ptr.T("b")},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_EQ": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(2)},
+					"int_column":     []*int32{ptr.Int32(20)},
+					"varchar_column": []*string{ptr.T("b")},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_GE": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(2), ptr.Int32(3)},
+					"int_column":     []*int32{ptr.Int32(20), ptr.Int32(30)},
+					"varchar_column": []*string{ptr.T("b"), ptr.T("c")},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_G": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(1), ptr.Int32(2), ptr.Int32(3)},
+					"int_column":     []*int32{ptr.Int32(10), ptr.Int32(20), ptr.Int32(30)},
+					"varchar_column": []*string{ptr.T("a"), ptr.T("b"), ptr.T("c")},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_NE": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(2), ptr.Int32(3), ptr.Int32(4)},
+					"int_column":     []*int32{ptr.Int32(20), ptr.Int32(30), nil},
+					"varchar_column": []*string{ptr.T("b"), ptr.T("c"), nil},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_NULL": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(4)},
+					"int_column":     []*int32{nil},
+					"varchar_column": []*string{nil},
+				},
+			},
+		},
+	},
+	"pushdown_comparison_NOT_NULL": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(1), ptr.Int32(2), ptr.Int32(3)},
+					"int_column":     []*int32{ptr.Int32(10), ptr.Int32(20), ptr.Int32(30)},
+					"varchar_column": []*string{ptr.T("a"), ptr.T("b"), ptr.T("c")},
+				},
+			},
+		},
+	},
+	"pushdown_conjunction": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(2), ptr.Int32(3)},
+					"int_column":     []*int32{ptr.Int32(20), ptr.Int32(30)},
+					"varchar_column": []*string{ptr.T("b"), ptr.T("c")},
+				},
+			},
+		},
+	},
+	"pushdown_disjunction": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(1), ptr.Int32(2), ptr.Int32(3)},
+					"int_column":     []*int32{ptr.Int32(10), ptr.Int32(20), ptr.Int32(30)},
+					"varchar_column": []*string{ptr.T("a"), ptr.T("b"), ptr.T("c")},
+				},
+			},
+		},
+	},
+	"pushdown_negation": {
+		Name:   "pushdown",
+		Schema: pushdownSchemaYdb(),
+		Records: []*test_utils.Record{
+			{
+				Columns: map[string]any{
+					"id":             []*int32{ptr.Int32(4)},
+					"int_column":     []*int32{nil},
+					"varchar_column": []*string{nil},
+				},
+			},
+		},
+	},
+}
+
+func pushdownSchemaYdb() *test_utils.TableSchema {
+	return &test_utils.TableSchema{
+		Columns: map[string]*Ydb.Type{
+			"id":             common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+			"int_column":     common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+			"varchar_column": common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+		},
+	}
 }


### PR DESCRIPTION
Enable pushdown expressions in SQL Formatter and enable relevant tests from the suite