### PR TITLE
shrink placeholder declaration: Optional<type> -> type?

### DIFF
--- a/app/server/datasource/rdbms/ydb/connection_native.go
+++ b/app/server/datasource/rdbms/ydb/connection_native.go
@@ -279,7 +279,7 @@ func (c *connectionNative) rewriteQuery(params *rdbms_utils.QueryParams) (string
 		}
 
 		if arg.YdbType.GetOptionalType() != nil {
-			typeName = fmt.Sprintf("Optional<%s>", typeName)
+			typeName = fmt.Sprintf("%s?", typeName)
 		}
 
 		buf.WriteString(fmt.Sprintf("DECLARE $p%d AS %s;\n", i, typeName)) //nolint:revive


### PR DESCRIPTION
Background: GenericLookup queries contains up to n*1k placeholders, this change saves some bandwidth/parse time
Completely untested