### PR TITLE
MongoDB: switch `_id` to optional type

### DIFF
--- a/app/server/datasource/nosql/mongodb/document_reader.go
+++ b/app/server/datasource/nosql/mongodb/document_reader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ydb-platform/fq-connector-go/app/server/paging"
 	"github.com/ydb-platform/fq-connector-go/app/server/utils"
 	"github.com/ydb-platform/fq-connector-go/common"
+	"github.com/ydb-platform/fq-connector-go/library/go/ptr"
 )
 
 type unexpectedTypeDisplayMode = api_common.TMongoDbDataSourceOptions_EUnexpectedTypeDisplayMode
@@ -148,8 +149,7 @@ func bsonDToString(doc bson.D) (string, error) {
 
 func convert[INTO any](acceptor **INTO, value any) {
 	if v, ok := value.(INTO); ok {
-		*acceptor = new(INTO)
-		**acceptor = v
+		*acceptor = ptr.T(v)
 	} else {
 		*acceptor = nil
 	}
@@ -180,6 +180,7 @@ func (r *documentReader) accept(logger *zap.Logger, doc bson.M) error {
 		case *string:
 			value, ok := doc[f.Name]
 			if !ok {
+				acceptors[i] = nil
 				continue
 			}
 
@@ -215,8 +216,7 @@ func (r *documentReader) accept(logger *zap.Logger, doc bson.M) error {
 				}
 			}
 
-			*a = new(string)
-			**a = str
+			*a = ptr.T(str)
 
 		case *primitive.Binary:
 			*a = doc[f.Name].(primitive.Binary)
@@ -233,8 +233,6 @@ func (r *documentReader) accept(logger *zap.Logger, doc bson.M) error {
 			return common.ErrDataTypeNotSupported
 		}
 	}
-
-	r.transformer.SetAcceptors(acceptors)
 
 	return nil
 }

--- a/app/server/datasource/nosql/mongodb/type_mapping.go
+++ b/app/server/datasource/nosql/mongodb/type_mapping.go
@@ -16,7 +16,6 @@ import (
 var errEmptyArray = errors.New("can't determine field type for items in an empty array")
 var errNull = errors.New("can't determine field type for null")
 
-const idColumn string = "_id"
 const objectIdTag string = "ObjectId"
 
 type readingMode = api_common.TMongoDbDataSourceOptions_EReadingMode
@@ -154,11 +153,7 @@ func bsonToYql(logger *zap.Logger, docs []bson.Raw, omitUnsupported bool) ([]*Yd
 	columns := make([]*Ydb.Column, 0, len(deducedTypes))
 
 	for columnName, deducedType := range deducedTypes {
-		if columnName == idColumn {
-			columns = append(columns, &Ydb.Column{Name: columnName, Type: deducedType})
-		} else {
-			columns = append(columns, &Ydb.Column{Name: columnName, Type: common.MakeOptionalType(deducedType)})
-		}
+		columns = append(columns, &Ydb.Column{Name: columnName, Type: common.MakeOptionalType(deducedType)})
 	}
 
 	return columns, nil

--- a/tests/infra/datasource/mongodb/tables.go
+++ b/tests/infra/datasource/mongodb/tables.go
@@ -13,7 +13,7 @@ import (
 
 var memPool memory.Allocator = memory.NewGoAllocator()
 
-var testIdType = common.MakePrimitiveType(Ydb.Type_INT32)
+var testIdType = common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32))
 var objectIdType = common.MakeTaggedType("ObjectId", common.MakePrimitiveType(Ydb.Type_STRING))
 
 var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
@@ -30,7 +30,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
-				"_id": []int32{0, 1, 2},
+				"_id": []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
 				"a":   []*string{ptr.String("jelly"), ptr.String("butter"), ptr.String("toast")},
 				"b":   []*int32{ptr.Int32(2000), ptr.Int32(-20021), ptr.Int32(2076)},
 				"c":   []*int64{ptr.Int64(13), ptr.Int64(0), ptr.Int64(2076)},
@@ -54,7 +54,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
-				"_id":     []int32{0, 1, 2},
+				"_id":     []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
 				"int32":   []*int32{ptr.Int32(42), ptr.Int32(13), ptr.Int32(15)},
 				"int64":   []*int64{ptr.Int64(23423), ptr.Int64(13), ptr.Int64(15)},
 				"string":  []*string{ptr.String("hello"), ptr.String("hi"), ptr.String("bye")},
@@ -86,7 +86,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
-				"_id":      []int32{0, 1, 2},
+				"_id":      []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
 				"int32":    []*int32{ptr.Int32(32), ptr.Int32(64), nil},
 				"int64":    []*int64{ptr.Int64(23423), nil, nil},
 				"string":   []*string{ptr.String("outer"), nil, nil},
@@ -112,7 +112,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
-				"_id": []int32{0, 1},
+				"_id": []*int32{ptr.Int32(0), ptr.Int32(1)},
 				"a":   []*string{ptr.String("32"), ptr.String("42")},
 				"b":   []*string{ptr.String("{foo: 32}"), ptr.String("b")},
 				"c":   []*string{ptr.String("bye"), ptr.String("rKw=")},
@@ -157,7 +157,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
-				"_id":     []int32{2202},
+				"_id":     []*int32{ptr.Int32(2202)},
 				"decimal": []*string{ptr.String("9823.1297")},
 			},
 		}},


### PR DESCRIPTION
First version of schema inference relied on a wrong assumption that there may be any guarantee about the type of the "_id" column, while there is none:
<img width="632" alt="Screenshot 2025-04-17 at 10 52 21" src="https://github.com/user-attachments/assets/cce323f9-124c-4c99-a511-666facd9ba31" />


Any field of any document in a given collection can be of any type, and despite the fact that "_id" is always present, we cannot expect it to be of a certain type, and therefore cannot guarantee that we can translate the "_id" field of any document to the YQL type we have inferred in the DescribeTable phase. Therefore it must be optional. 