### PR TITLE
MongoDB: predicate pushdown for simple queries

### DIFF
--- a/app/server/datasource/nosql/mongodb/datasource.go
+++ b/app/server/datasource/nosql/mongodb/datasource.go
@@ -231,7 +231,7 @@ func (ds *dataSource) doReadSplitSingleConn(
 		return fmt.Errorf("failed to make filter: %w", err)
 	}
 
-	logger.Debug(fmt.Sprintf("Filter: %v", filter))
+	logger.Debug("Query filter", zap.Any("filter", filter))
 
 	var cursor *mongo.Cursor
 

--- a/app/server/datasource/nosql/mongodb/datasource.go
+++ b/app/server/datasource/nosql/mongodb/datasource.go
@@ -219,19 +219,23 @@ func (ds *dataSource) doReadSplitSingleConn(
 	logger *zap.Logger,
 	dsi *api_common.TGenericDataSourceInstance,
 	mongoDbOptions *api_common.TMongoDbDataSourceOptions,
-	_ *api_service_protos.TReadSplitsRequest,
+	request *api_service_protos.TReadSplitsRequest,
 	split *api_service_protos.TSplit,
 	sink paging.Sink[any],
 	conn *mongo.Client,
 ) error {
 	collection := conn.Database(dsi.Database).Collection(split.Select.From.Table)
 
-	filter := bson.D{}
-	opts := options.Find()
+	filter, opts, err := makeFilter(logger, split, request.GetFiltering())
+	if err != nil {
+		return fmt.Errorf("failed to make filter: %w", err)
+	}
+
+	logger.Debug(fmt.Sprintf("Filter: %v", filter))
 
 	var cursor *mongo.Cursor
 
-	err := ds.retrierSet.Query.Run(
+	err = ds.retrierSet.Query.Run(
 		ctx,
 		logger,
 		func() error {

--- a/app/server/datasource/nosql/mongodb/docs/demo.md
+++ b/app/server/datasource/nosql/mongodb/docs/demo.md
@@ -427,3 +427,161 @@ rows {
   }
 }
 ```
+
+#### Запрос с фильтрацией по первичному ключу типа ObjectId
+
+Файл с телом запроса
+
+bar.yql
+```sql
+SELECT * FROM mongodb_external_datasource.bar WHERE _id = AsTagged('67f3c139171bfd11df51e944', 'ObjectId');
+```
+
+Команда запроса
+
+```sh
+./ydb/tests/tools/kqprun/kqprun -s ydb/schema.yql -p ydb/bar.yql --app-config=ydb/app_conf.txt --result-format="full-proto"
+```
+
+Вывод результата выполнения команды без логов:
+
+```
+columns {
+  name: "_id"
+  type {
+    optional_type {
+      item {
+        tagged_type {
+          tag: "ObjectId"
+          type {
+            type_id: STRING
+          }
+        }
+      }
+    }
+  }
+}
+columns {
+  name: "a"
+  type {
+    optional_type {
+      item {
+        type_id: UTF8
+      }
+    }
+  }
+}
+columns {
+  name: "b"
+  type {
+    optional_type {
+      item {
+        type_id: INT32
+      }
+    }
+  }
+}
+columns {
+  name: "c"
+  type {
+    optional_type {
+      item {
+        type_id: INT64
+      }
+    }
+  }
+}
+rows {
+  items {
+    bytes_value: "67f3c139171bfd11df51e944"
+  }
+  items {
+    text_value: "jelly"
+  }
+  items {
+    int32_value: 2000
+  }
+  items {
+    int64_value: 13
+  }
+}
+```
+
+#### Запрос с оператором LIKE
+
+Файл с телом запроса
+
+bar.yql
+```sql
+SELECT * FROM mongodb_external_datasource.bar WHERE a LIKE 'toast';
+```
+
+Команда запроса
+
+```sh
+./ydb/tests/tools/kqprun/kqprun -s ydb/schema.yql -p ydb/bar.yql --app-config=ydb/app_conf.txt --result-format="full-proto"
+```
+
+Вывод результата выполнения команды без логов:
+
+```
+columns {
+  name: "_id"
+  type {
+    optional_type {
+      item {
+        tagged_type {
+          tag: "ObjectId"
+          type {
+            type_id: STRING
+          }
+        }
+      }
+    }
+  }
+}
+columns {
+  name: "a"
+  type {
+    optional_type {
+      item {
+        type_id: UTF8
+      }
+    }
+  }
+}
+columns {
+  name: "b"
+  type {
+    optional_type {
+      item {
+        type_id: INT32
+      }
+    }
+  }
+}
+columns {
+  name: "c"
+  type {
+    optional_type {
+      item {
+        type_id: INT64
+      }
+    }
+  }
+}
+rows {
+  items {
+    bytes_value: "67f3c139171bfd11df51e946"
+  }
+  items {
+    text_value: "toast"
+  }
+  items {
+    int32_value: 2076
+  }
+  items {
+    int64_value: 2076
+  }
+}
+```

--- a/app/server/datasource/nosql/mongodb/filtering.go
+++ b/app/server/datasource/nosql/mongodb/filtering.go
@@ -1,0 +1,426 @@
+package mongodb
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+
+	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
+	"github.com/ydb-platform/fq-connector-go/common"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+)
+
+func makeFilter(
+	logger *zap.Logger,
+	split *api_service_protos.TSplit,
+	filtering api_service_protos.TReadSplitsRequest_EFiltering,
+) (bson.D, *options.FindOptions, error) {
+	opts := options.Find()
+
+	what := split.Select.What
+	if what != nil {
+		projection := bson.D{}
+		for _, item := range what.GetItems() {
+			projection = append(projection, bson.E{item.GetColumn().Name, 1})
+		}
+
+		opts.SetProjection(projection)
+	}
+
+	limit := split.Select.Limit
+	if limit != nil {
+		opts.SetSkip(int64(limit.Offset))
+		opts.SetLimit(int64(limit.Limit))
+		// opts.SetSort() ORDER BY :(
+	}
+
+	where := split.Select.Where
+	filterTyped := where.GetFilterTyped()
+	if filterTyped == nil {
+		logger.Warn("handling nil filter")
+
+		return bson.D{}, opts, nil
+	}
+
+	filter, err := makePredicateFilter(filterTyped)
+	if err != nil {
+		switch filtering {
+		case api_service_protos.TReadSplitsRequest_FILTERING_MANDATORY:
+			return nil, nil, fmt.Errorf("encountered an error making a filter: %w", err)
+		case api_service_protos.TReadSplitsRequest_FILTERING_UNSPECIFIED,
+			api_service_protos.TReadSplitsRequest_FILTERING_OPTIONAL:
+			if common.AcceptableErrors.Match(err) {
+				logger.Info("considering pushdown error as acceptable", zap.Error(err))
+				return filter, opts, nil
+			}
+			return nil, nil, fmt.Errorf("encountered an error making a filter: %w", err)
+		default:
+			return nil, nil, fmt.Errorf("unknown filtering mode: %d", filtering)
+		}
+	}
+
+	return filter, opts, nil
+}
+
+func makePredicateFilter(
+	predicate *api_service_protos.TPredicate,
+) (bson.D, error) {
+	var (
+		result bson.D
+		err    error
+	)
+
+	switch p := predicate.Payload.(type) {
+	case *api_service_protos.TPredicate_IsNull:
+		result, err = getIsNullFilter(p.IsNull.GetValue())
+		if err != nil {
+			return result, fmt.Errorf("get IsNull filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_IsNotNull:
+		result, err = getIsNotNullFilter(p.IsNotNull.GetValue())
+		if err != nil {
+			return result, fmt.Errorf("get IsNotNull filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Negation:
+		result, err = getNegationFilter(p.Negation)
+		if err != nil {
+			return result, fmt.Errorf("get Negation filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Conjunction:
+		result, err = getConjunctionFilter(p.Conjunction)
+		if err != nil {
+			return result, fmt.Errorf("get Conjunction filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Disjunction:
+		result, err = getDisjunctionFilter(p.Disjunction)
+		if err != nil {
+			return result, fmt.Errorf("get Disjunction filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Comparison:
+		result, err = getComparisonFilter(p.Comparison)
+		if err != nil {
+			return result, fmt.Errorf("get Comparison filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_BoolExpression:
+		result, err = getBooleanFilter(p.BoolExpression)
+		if err != nil {
+			return result, fmt.Errorf("get BoolExpression filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_In:
+		result, err = getInSetFilter(p.In)
+		if err != nil {
+			return result, fmt.Errorf("get InSet filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Between:
+		result, err = getBetweenFilter(p.Between)
+		if err != nil {
+			return result, fmt.Errorf("get Between filter: %w", err)
+		}
+	case *api_service_protos.TPredicate_Regexp:
+		result, err = getRegexFilter(p.Regexp)
+		if err != nil {
+			return result, fmt.Errorf("get If filter: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("%w, type: %T", common.ErrUnimplementedPredicateType, p)
+	}
+
+	return result, nil
+}
+
+func getNegationFilter(
+	negation *api_service_protos.TPredicate_TNegation,
+) (bson.D, error) {
+	operand, err := makePredicateFilter(negation.Operand)
+	if err != nil {
+		return nil, err
+	}
+
+	return bson.D{{"$nor", bson.A{operand}}}, nil
+}
+
+func getBooleanFilter(
+	boolExpression *api_service_protos.TPredicate_TBoolExpression,
+) (bson.D, error) {
+	expr, err := formatExpression(boolExpression.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return bson.D{{"$expr", bson.D{{"$eq", bson.A{expr, true}}}}}, nil
+}
+
+func getConjunctionFilter(
+	conjunction *api_service_protos.TPredicate_TConjunction,
+) (bson.D, error) {
+	operands := make([]bson.D, 0, len(conjunction.Operands))
+	for _, op := range conjunction.Operands {
+		operand, err := makePredicateFilter(op)
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, operand)
+	}
+
+	return bson.D{{"$and", operands}}, nil
+}
+
+func getDisjunctionFilter(
+	disjunction *api_service_protos.TPredicate_TDisjunction,
+) (bson.D, error) {
+
+	operands := make([]bson.D, 0, len(disjunction.Operands))
+	for _, op := range disjunction.Operands {
+		operand, err := makePredicateFilter(op)
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, operand)
+	}
+
+	return bson.D{{"$or", operands}}, nil
+}
+
+func getIsNotNullFilter(expression *api_service_protos.TExpression) (bson.D, error) {
+	switch e := expression.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		return bson.D{{e.Column, bson.D{{"$ne", nil}}}}, nil
+	default:
+		return nil, common.ErrUnimplementedPredicateType
+	}
+}
+
+func getIsNullFilter(expression *api_service_protos.TExpression) (bson.D, error) {
+	switch e := expression.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		return bson.D{
+			{"$or", bson.A{
+				bson.D{{e.Column, bson.D{{"$exists", false}}}},
+				bson.D{{e.Column, bson.D{{"$eq", nil}}}},
+			}},
+		}, nil
+	default:
+		return nil, common.ErrUnimplementedPredicateType
+	}
+}
+
+func getComparisonFilter(comparison *api_service_protos.TPredicate_TComparison) (bson.D, error) {
+	var operation string
+
+	switch op := comparison.Operation; op {
+	case api_service_protos.TPredicate_TComparison_L:
+		operation = "$lt"
+	case api_service_protos.TPredicate_TComparison_LE:
+		operation = "$lte"
+	case api_service_protos.TPredicate_TComparison_EQ:
+		operation = "$eq"
+	case api_service_protos.TPredicate_TComparison_NE:
+		operation = "$ne"
+	case api_service_protos.TPredicate_TComparison_GE:
+		operation = "$gte"
+	case api_service_protos.TPredicate_TComparison_G:
+		operation = "$gt"
+	default:
+		return nil, fmt.Errorf("%w, op: %d", common.ErrUnimplementedOperation, op)
+	}
+
+	left, err := formatExpression(comparison.LeftValue)
+	if err != nil {
+		return nil, fmt.Errorf("format left expression: %v: %w", comparison.LeftValue, err)
+	}
+
+	right, err := formatExpression(comparison.RightValue)
+	if err != nil {
+		return nil, fmt.Errorf("format right expression: %v: %w", comparison.RightValue, err)
+	}
+
+	return bson.D{{"$expr", bson.D{{operation, bson.A{left, right}}}}}, nil
+}
+
+func getInSetFilter(
+	in *api_service_protos.TPredicate_TIn,
+) (bson.D, error) {
+	var fieldName string
+	switch e := in.Value.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		fieldName = e.Column
+	default:
+		return nil, common.ErrUnimplementedPredicateType
+	}
+
+	inSet := make([]any, 0, len(in.Set))
+	for _, e := range in.Set {
+		expr, err := formatExpression(e)
+		if err != nil {
+			return nil, err
+		}
+
+		inSet = append(inSet, expr)
+	}
+
+	return bson.D{{fieldName, bson.D{{"$in", inSet}}}}, nil
+}
+
+func getBetweenFilter(
+	between *api_service_protos.TPredicate_TBetween,
+) (bson.D, error) {
+	var fieldName string
+
+	switch e := between.Value.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		fieldName = e.Column
+	default:
+		return nil, common.ErrUnimplementedPredicateType
+	}
+
+	least, err := formatExpression(between.Least)
+	if err != nil {
+		return nil, fmt.Errorf("format least expression: %v: %w", between.Least, err)
+	}
+
+	greatest, err := formatExpression(between.Greatest)
+	if err != nil {
+		return nil, fmt.Errorf("format greatest expression: %v: %w", between.Greatest, err)
+	}
+
+	return bson.D{{fieldName,
+		bson.D{
+			{"$gte", least},
+			{"$lte", greatest},
+		},
+	}}, nil
+}
+
+func getRegexFilter(
+	regex *api_service_protos.TPredicate_TRegexp,
+) (bson.D, error) {
+	var fieldName string
+
+	switch e := regex.Value.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		fieldName = e.Column
+	default:
+		return nil, common.ErrUnimplementedExpression
+	}
+
+	pattern, err := formatExpression(regex.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("format regex pattern expression: %v: %w", regex.Pattern, err)
+	}
+
+	return bson.D{{fieldName, bson.D{{"$regex", pattern}}}}, nil
+}
+
+func formatExpression(expression *api_service_protos.TExpression) (any, error) {
+	switch e := expression.Payload.(type) {
+	case *api_service_protos.TExpression_Column:
+		return fmt.Sprintf("$%v", e.Column), nil
+	case *api_service_protos.TExpression_TypedValue:
+		return formatTypedValue(e.TypedValue)
+	case *api_service_protos.TExpression_Null:
+		return nil, nil
+	case *api_service_protos.TExpression_Coalesce:
+		return formatCoalesce(e.Coalesce)
+	default:
+		return nil, fmt.Errorf("%w, type: %T", common.ErrUnimplementedExpression, e)
+	}
+}
+
+func formatTypedValue(expr *Ydb.TypedValue) (any, error) {
+	v := expr.GetValue()
+	ydbType := expr.GetType()
+	if v == nil || v.Value == nil || ydbType == nil {
+		return nil, fmt.Errorf("got %v of type %T as null trying to format Typed Value expression", v, v)
+	}
+
+	var value any
+	switch t := v.Value.(type) {
+	case *Ydb.Value_BoolValue:
+		value = t.BoolValue
+	case *Ydb.Value_Int32Value:
+		value = t.Int32Value
+	case *Ydb.Value_Uint32Value:
+		value = t.Uint32Value
+	case *Ydb.Value_Int64Value:
+		value = t.Int64Value
+	case *Ydb.Value_Uint64Value:
+		value = t.Uint64Value
+	case *Ydb.Value_FloatValue:
+		value = t.FloatValue
+	case *Ydb.Value_DoubleValue:
+		value = t.DoubleValue
+	case *Ydb.Value_BytesValue:
+		value = t.BytesValue
+	case *Ydb.Value_TextValue:
+		value = t.TextValue
+	default:
+		return nil, fmt.Errorf("%w, type: %T", common.ErrUnimplementedTypedValue, t)
+	}
+
+	value, err := tryFormatObjectId(ydbType, value)
+	if err != nil {
+		return nil, fmt.Errorf("%w %w", err, common.ErrUnimplementedTypedValue)
+	}
+
+	return value, nil
+}
+
+func formatCoalesce(expr *api_service_protos.TExpression_TCoalesce) (any, error) {
+	operands := make([]any, 0, len(expr.Operands))
+	for _, opExpr := range expr.Operands {
+		op, err := formatExpression(opExpr)
+		if err != nil {
+			return nil, fmt.Errorf("error formatting coalesce expression: %w", err)
+		}
+
+		operands = append(operands, op)
+	}
+
+	return bson.D{{"$ifNull", operands}}, nil
+}
+
+func tryFormatObjectId(exprType *Ydb.Type, value any) (any, error) {
+	for exprType.GetOptionalType() != nil {
+		exprType = exprType.GetOptionalType().GetItem()
+	}
+
+	switch t := exprType.Type.(type) {
+	case *Ydb.Type_TaggedType:
+		if !common.TypesEqual(exprType, objectIdType) {
+			return nil, fmt.Errorf("unknown Tagged type: %T", exprType)
+		}
+
+		var hexString string
+
+		switch b := value.(type) {
+		case []byte:
+			hexString = hex.EncodeToString(b)
+		case string:
+			hexString = b
+		default:
+			return nil, fmt.Errorf("wrong value of TypedValue for ObjectId: %v", value)
+		}
+
+		v, err := primitive.ObjectIDFromHex(hexString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct ObjectId from %s %v: %w", hexString, value, err)
+		}
+
+		return v, nil
+	case *Ydb.Type_TypeId:
+		switch t.TypeId {
+		case Ydb.Type_BOOL, Ydb.Type_INT8, Ydb.Type_UINT8, Ydb.Type_INT16,
+			Ydb.Type_UINT16, Ydb.Type_INT32, Ydb.Type_UINT32, Ydb.Type_INT64,
+			Ydb.Type_UINT64, Ydb.Type_FLOAT, Ydb.Type_DOUBLE, Ydb.Type_STRING, Ydb.Type_UTF8:
+			return value, nil
+		default:
+			return nil, fmt.Errorf("unsupported type %T for typed value", t)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported type %T for typed value", t)
+	}
+}

--- a/app/server/datasource/nosql/mongodb/type_mapping.go
+++ b/app/server/datasource/nosql/mongodb/type_mapping.go
@@ -18,6 +18,8 @@ var errNull = errors.New("can't determine field type for null")
 
 const objectIdTag string = "ObjectId"
 
+var objectIdType *Ydb.Type = common.MakeTaggedType(objectIdTag, common.MakePrimitiveType(Ydb.Type_STRING))
+
 type readingMode = api_common.TMongoDbDataSourceOptions_EReadingMode
 
 func typeMap(logger *zap.Logger, v bson.RawValue) (*Ydb.Type, error) {
@@ -35,7 +37,7 @@ func typeMap(logger *zap.Logger, v bson.RawValue) (*Ydb.Type, error) {
 	case bson.TypeBinary:
 		return common.MakePrimitiveType(Ydb.Type_STRING), nil
 	case bson.TypeObjectID:
-		return common.MakeTaggedType(objectIdTag, common.MakePrimitiveType(Ydb.Type_STRING)), nil
+		return objectIdType, nil
 	case bson.TypeNull:
 		return nil, errNull
 	default:

--- a/app/server/datasource/rdbms/utils/predicate_builder.go
+++ b/app/server/datasource/rdbms/utils/predicate_builder.go
@@ -528,12 +528,6 @@ func (pb *predicateBuilder) formatPredicate(
 	return result, nil
 }
 
-var acceptableErrors = common.NewErrorMatcher(
-	common.ErrUnsupportedExpression,
-	common.ErrUnimplementedPredicateType,
-	common.ErrUnimplementedTypedValue,
-)
-
 func formatWhereClause(
 	logger *zap.Logger,
 	filtering api_service_protos.TReadSplitsRequest_EFiltering,
@@ -557,7 +551,7 @@ func formatWhereClause(
 			logger.Warn("failed to pushdown some parts of WHERE clause", zap.Error(conjunctionErr))
 		}
 
-		if acceptableErrors.Match(err) {
+		if common.AcceptableErrors.Match(err) {
 			logger.Info("considering pushdown error as acceptable", zap.Error(err))
 			return clause, pb.args, nil
 		}

--- a/app/server/datasource/rdbms/utils/predicate_builder.go
+++ b/app/server/datasource/rdbms/utils/predicate_builder.go
@@ -551,8 +551,8 @@ func formatWhereClause(
 			logger.Warn("failed to pushdown some parts of WHERE clause", zap.Error(conjunctionErr))
 		}
 
-		if common.AcceptableErrors.Match(err) {
-			logger.Info("considering pushdown error as acceptable", zap.Error(err))
+		if common.OptionalFilteringAllowedErrors.Match(err) {
+			logger.Warn("considering pushdown error as acceptable", zap.Error(err))
 			return clause, pb.args, nil
 		}
 

--- a/common/errors.go
+++ b/common/errors.go
@@ -46,6 +46,12 @@ var (
 	ErrPageSizeExceeded                    = fmt.Errorf("page size exceeded, check service configuration")
 )
 
+var AcceptableErrors = NewErrorMatcher(
+	ErrUnsupportedExpression,
+	ErrUnimplementedPredicateType,
+	ErrUnimplementedTypedValue,
+)
+
 var (
 	// TODO: remove this and extract MyError somehow
 	mysqlRegex = regexp.MustCompile(`\d+`)

--- a/common/errors.go
+++ b/common/errors.go
@@ -46,7 +46,7 @@ var (
 	ErrPageSizeExceeded                    = fmt.Errorf("page size exceeded, check service configuration")
 )
 
-var AcceptableErrors = NewErrorMatcher(
+var OptionalFilteringAllowedErrors = NewErrorMatcher(
 	ErrUnsupportedExpression,
 	ErrUnimplementedPredicateType,
 	ErrUnimplementedTypedValue,

--- a/common/ydb_type_helpers.go
+++ b/common/ydb_type_helpers.go
@@ -42,6 +42,10 @@ func MakeTypedValue(ydbType *Ydb.Type, value any) *Ydb.TypedValue {
 		out.Value.Value = &Ydb.Value_TextValue{TextValue: v}
 	case []byte:
 		out.Value.Value = &Ydb.Value_BytesValue{BytesValue: v}
+	case float64:
+		out.Value.Value = &Ydb.Value_DoubleValue{DoubleValue: v}
+	case bool:
+		out.Value.Value = &Ydb.Value_BoolValue{BoolValue: v}
 	case nil:
 		out.Value.Value = &Ydb.Value_NullFlagValue{}
 	default:

--- a/tests/infra/datasource/mongodb/datasource.go
+++ b/tests/infra/datasource/mongodb/datasource.go
@@ -23,7 +23,7 @@ var defaultMongoDbOptions = &api_common.TGenericDataSourceInstance_MongodbOption
 		UnexpectedTypeDisplayMode:  api_common.TMongoDbDataSourceOptions_UNEXPECTED_AS_STRING,
 	}}
 
-var stringifyMongoDbOptions = &api_common.TGenericDataSourceInstance_MongodbOptions{
+var asStringMongoDbOptions = &api_common.TGenericDataSourceInstance_MongodbOptions{
 	MongodbOptions: &api_common.TMongoDbDataSourceOptions{
 		ReadingMode:                api_common.TMongoDbDataSourceOptions_TABLE,
 		UnsupportedTypeDisplayMode: api_common.TMongoDbDataSourceOptions_UNSUPPORTED_AS_STRING,

--- a/tests/infra/datasource/mongodb/init/init.sh
+++ b/tests/infra/datasource/mongodb/init/init.sh
@@ -189,4 +189,19 @@ db.similar.insertMany( [
     },
 ]);
 
+db.strcomp.insertMany( [
+    {
+        _id: Int32(0),
+        a: "abc__",
+    },
+    {
+        _id: Int32(1),
+        a: "__abc",
+    },
+    {
+        _id: Int32(2),
+        a: "__abc__",
+    },
+]);
+
 EOF

--- a/tests/infra/datasource/mongodb/init/init.sh
+++ b/tests/infra/datasource/mongodb/init/init.sh
@@ -62,20 +62,20 @@ db.primitives.insertMany( [
 db.missing.insertMany( [
     {
         _id: Int32(0),
-        int32: Int32(32),
+        int32: Int32(64),
         int64: Long(23423),
         string: "outer",
         double: 1.1,
+        binary: Binary.createFromHexString("abcd"),
         boolean: false,
+        objectid: ObjectId('171e75500ecde1c75c59139e'),
     },
     {
         _id: Int32(1),
-        int32: Int32(64),
+        int32: Int32(32),
         double: 1.2,
         boolean: true,
         decimal: NumberDecimal("9823.1297"),
-        binary: Binary.createFromHexString("abcd"),
-        objectid: ObjectId('171e75500ecde1c75c59139e'),
     },
     {
         _id: Int32(2),
@@ -149,5 +149,44 @@ db.unsupported.insertOne(
         decimal: NumberDecimal("9823.1297"),
     }
 );
+
+db.similar.insertMany( [
+    {
+        _id: Int32(0),
+        a: Int32(1),
+        b: "hello",
+    },
+    {
+        _id: Int32(1),
+        a: Int32(1),
+        b: "hi",
+    },
+    {
+        _id: Int32(2),
+        a: Int32(2),
+        b: "hello",
+    },
+    {
+        _id: Int32(3),
+        a: Int32(2),
+        b: "one",
+    },
+    {
+        _id: Int32(4),
+        a: Int32(2),
+        b: "two",
+    },
+    {
+        _id: Int32(5),
+        a: Int32(6),
+        b: "three",
+    },
+    {
+        _id: Int32(6),
+        a: Int32(9),
+        b: "four",
+        c: "surprise",
+    },
+]);
 
 EOF

--- a/tests/infra/datasource/mongodb/suite.go
+++ b/tests/infra/datasource/mongodb/suite.go
@@ -4,7 +4,12 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/array"
 
 	"github.com/ydb-platform/fq-connector-go/tests/infra/datasource"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+
+	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
+	"github.com/ydb-platform/fq-connector-go/common"
 	"github.com/ydb-platform/fq-connector-go/tests/suite"
+	tests_utils "github.com/ydb-platform/fq-connector-go/tests/utils"
 )
 
 type Suite struct {
@@ -12,10 +17,20 @@ type Suite struct {
 	dataSource *datasource.DataSource
 }
 
-func (s *Suite) TestReadSplitPrimitives() {
+func (s *Suite) SetDefaultOptions() {
 	for _, instance := range s.dataSource.Instances {
 		instance.Options = defaultMongoDbOptions
 	}
+}
+
+func (s *Suite) SetAsStringOptions() {
+	for _, instance := range s.dataSource.Instances {
+		instance.Options = asStringMongoDbOptions
+	}
+}
+
+func (s *Suite) TestReadSplitPrimitives() {
+	s.SetDefaultOptions()
 
 	testCaseNames := []string{"simple", "primitives", "missing", "uneven"}
 
@@ -25,14 +40,346 @@ func (s *Suite) TestReadSplitPrimitives() {
 }
 
 func (s *Suite) TestIncludeUnsupported() {
-	for _, instance := range s.dataSource.Instances {
-		instance.Options = stringifyMongoDbOptions
-	}
+	s.SetAsStringOptions()
 
 	testCaseNames := []string{"unsupported"}
 	for _, testCase := range testCaseNames {
 		s.ValidateTable(s.dataSource, tables[testCase])
 	}
+}
+
+func (s *Suite) TestPushdownProjection() {
+	s.SetDefaultOptions()
+
+	what := &api_service_protos.TSelect_TWhat{
+		Items: []*api_service_protos.TSelect_TWhat_TItem{
+			{
+				Payload: &api_service_protos.TSelect_TWhat_TItem_Column{
+					Column: &Ydb.Column{
+						Name: "_id",
+						Type: common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+					},
+				},
+			},
+			{
+				Payload: &api_service_protos.TSelect_TWhat_TItem_Column{
+					Column: &Ydb.Column{
+						Name: "int32",
+						Type: common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+					},
+				},
+			},
+		},
+	}
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["primitives_int32"],
+		suite.WithWhat(what),
+	)
+}
+
+func (s *Suite) TestPushdownIsNull() {
+	s.SetDefaultOptions()
+
+	testCaseNames := []string{"int32", "double", "boolean"}
+	for _, testCase := range testCaseNames {
+		s.ValidateTable(
+			s.dataSource,
+			tables["missing_2"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: tests_utils.MakePredicateIsNullColumn(
+					testCase,
+				),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownIsNotNull() {
+	s.SetDefaultOptions()
+
+	testCaseNames := []string{"int64", "string", "objectid"}
+	for _, testCase := range testCaseNames {
+		s.ValidateTable(
+			s.dataSource,
+			tables["missing_0"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: tests_utils.MakePredicateIsNotNullColumn(
+					testCase,
+				),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownComparisonEQ() {
+	s.SetDefaultOptions()
+
+	testcases := map[string]*Ydb.TypedValue{
+		"_id":      common.MakeTypedValue(common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)), int32(0)),
+		"int32":    common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
+		"int64":    common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT64), int64(23423)),
+		"string":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), "outer"),
+		"binary":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), []byte{0xab, 0xcd}),
+		"double":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_DOUBLE), float64(1.1)),
+		"boolean":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_BOOL), false),
+		"objectid": common.MakeTypedValue(common.MakeTaggedType("ObjectId", common.MakePrimitiveType(Ydb.Type_STRING)), []byte{0x17, 0x1e, 0x75, 0x50, 0x0e, 0xcd, 0xe1, 0xc7, 0x5c, 0x59, 0x13, 0x9e}),
+	}
+
+	for column, value := range testcases {
+		s.ValidateTable(
+			s.dataSource,
+			tables["missing_0"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: tests_utils.MakePredicateComparisonColumn(
+					column,
+					api_service_protos.TPredicate_TComparison_EQ,
+					value,
+				),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownComparisonTwoColumns() {
+	s.SetDefaultOptions()
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["similar_056"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Comparison{
+				Comparison: &api_service_protos.TPredicate_TComparison{
+					LeftValue: &api_service_protos.TExpression{
+						Payload: &api_service_protos.TExpression_Column{Column: "_id"},
+					},
+					Operation: api_service_protos.TPredicate_TComparison_L,
+					RightValue: &api_service_protos.TExpression{
+						Payload: &api_service_protos.TExpression_Column{Column: "a"},
+					},
+				},
+			}}),
+	)
+}
+
+func (s *Suite) TestPushdownConjunction() {
+	s.SetDefaultOptions()
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["similar_0"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Conjunction{
+				Conjunction: &api_service_protos.TPredicate_TConjunction{
+					Operands: []*api_service_protos.TPredicate{
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"a",
+								api_service_protos.TPredicate_TComparison_EQ,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(1)),
+							),
+						},
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"b",
+								api_service_protos.TPredicate_TComparison_EQ,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hello"),
+							),
+						},
+					},
+				},
+			},
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownDisjunction() {
+	s.SetDefaultOptions()
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["similar_01"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: &api_service_protos.TPredicate_Disjunction{
+				Disjunction: &api_service_protos.TPredicate_TDisjunction{
+					Operands: []*api_service_protos.TPredicate{
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"_id",
+								api_service_protos.TPredicate_TComparison_EQ,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(0)),
+							),
+						},
+						{
+							Payload: tests_utils.MakePredicateComparisonColumn(
+								"b",
+								api_service_protos.TPredicate_TComparison_EQ,
+								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hi"),
+							),
+						},
+					},
+				},
+			},
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownNegation() {
+	s.SetDefaultOptions()
+
+	testCases := []*api_service_protos.TPredicate{
+		{
+			Payload: tests_utils.MakePredicateIsNotNullColumn(
+				"int64",
+			),
+		},
+		{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"_id",
+				api_service_protos.TPredicate_TComparison_EQ,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(0)),
+			),
+		},
+		{
+			Payload: tests_utils.MakePredicateComparisonColumn(
+				"int32",
+				api_service_protos.TPredicate_TComparison_GE,
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
+			),
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.ValidateTable(
+			s.dataSource,
+			tables["missing_12"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: &api_service_protos.TPredicate_Negation{
+					Negation: &api_service_protos.TPredicate_TNegation{
+						Operand: testCase,
+					},
+				},
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownBoolExpression() {
+	s.SetDefaultOptions()
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["missing_1"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateBoolExpressionColumn("boolean"),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownBetween() {
+	s.SetDefaultOptions()
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["similar_234"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: tests_utils.MakePredicateBetweenColumn(
+				"_id",
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(2)),
+				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(4)),
+			),
+		}),
+	)
+}
+
+func (s *Suite) TestPushdownIn() {
+	s.SetDefaultOptions()
+
+	testCases := map[string][]*Ydb.TypedValue{
+		"_id": {
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(1)),
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(4)),
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(6)),
+		},
+		"b": {
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hi"),
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "two"),
+			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "four"),
+		},
+	}
+
+	for column, valueSet := range testCases {
+		s.ValidateTable(
+			s.dataSource,
+			tables["similar_146"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: tests_utils.MakePredicateInColumn(
+					column, valueSet,
+				),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownRegex() {
+	s.SetDefaultOptions()
+
+	toastPatterns := []string{
+		"toast",
+		".+ast?",
+		"t.{4}",
+	}
+
+	for _, pattern := range toastPatterns {
+		s.ValidateTable(
+			s.dataSource,
+			tables["simple_last"],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: tests_utils.MakePredicateRegexpColumn("a", pattern),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownWithCoalesce() {
+	s.SetDefaultOptions()
+
+	// SELECT * FROM missing WHERE COALESCE('int32', 12) < 60;
+	predicate := &api_service_protos.TPredicate_Comparison{
+		Comparison: &api_service_protos.TPredicate_TComparison{
+			LeftValue: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_Coalesce{
+					Coalesce: &api_service_protos.TExpression_TCoalesce{
+						Operands: []*api_service_protos.TExpression{
+							{
+								Payload: &api_service_protos.TExpression_Column{Column: "int32"},
+							},
+							{
+								Payload: &api_service_protos.TExpression_TypedValue{
+									TypedValue: common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(12)),
+								},
+							},
+						},
+					},
+				},
+			},
+			Operation: api_service_protos.TPredicate_TComparison_L,
+			RightValue: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_TypedValue{
+					TypedValue: common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(60)),
+				},
+			},
+		},
+	}
+
+	s.ValidateTable(
+		s.dataSource,
+		tables["missing_12"],
+		suite.WithPredicate(&api_service_protos.TPredicate{
+			Payload: predicate,
+		}),
+	)
 }
 
 func NewSuite(

--- a/tests/infra/datasource/mongodb/suite.go
+++ b/tests/infra/datasource/mongodb/suite.go
@@ -3,11 +3,11 @@ package mongodb
 import (
 	"github.com/apache/arrow/go/v13/arrow/array"
 
-	"github.com/ydb-platform/fq-connector-go/tests/infra/datasource"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 
 	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
 	"github.com/ydb-platform/fq-connector-go/common"
+	"github.com/ydb-platform/fq-connector-go/tests/infra/datasource"
 	"github.com/ydb-platform/fq-connector-go/tests/suite"
 	tests_utils "github.com/ydb-platform/fq-connector-go/tests/utils"
 )
@@ -117,14 +117,18 @@ func (s *Suite) TestPushdownComparisonEQ() {
 	s.SetDefaultOptions()
 
 	testcases := map[string]*Ydb.TypedValue{
-		"_id":      common.MakeTypedValue(common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)), int32(0)),
-		"int32":    common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
-		"int64":    common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT64), int64(23423)),
-		"string":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), "outer"),
-		"binary":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), []byte{0xab, 0xcd}),
-		"double":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_DOUBLE), float64(1.1)),
-		"boolean":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_BOOL), false),
-		"objectid": common.MakeTypedValue(common.MakeTaggedType("ObjectId", common.MakePrimitiveType(Ydb.Type_STRING)), []byte{0x17, 0x1e, 0x75, 0x50, 0x0e, 0xcd, 0xe1, 0xc7, 0x5c, 0x59, 0x13, 0x9e}),
+		"_id":     common.MakeTypedValue(common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)), int32(0)),
+		"int32":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
+		"int64":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT64), int64(23423)),
+		"string":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), "outer"),
+		"binary":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), []byte{0xab, 0xcd}),
+		"double":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_DOUBLE), float64(1.1)),
+		"boolean": common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_BOOL), false),
+		"objectid": common.MakeTypedValue(
+			common.MakeTaggedType("ObjectId",
+				common.MakePrimitiveType(Ydb.Type_STRING)),
+			[]byte{0x17, 0x1e, 0x75, 0x50, 0x0e, 0xcd, 0xe1, 0xc7, 0x5c, 0x59, 0x13, 0x9e},
+		),
 	}
 
 	for column, value := range testcases {

--- a/tests/infra/datasource/mongodb/suite.go
+++ b/tests/infra/datasource/mongodb/suite.go
@@ -57,7 +57,7 @@ func (s *Suite) TestPushdownProjection() {
 				Payload: &api_service_protos.TSelect_TWhat_TItem_Column{
 					Column: &Ydb.Column{
 						Name: "_id",
-						Type: common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+						Type: Optional(Primitive(Ydb.Type_INT32)),
 					},
 				},
 			},
@@ -65,7 +65,7 @@ func (s *Suite) TestPushdownProjection() {
 				Payload: &api_service_protos.TSelect_TWhat_TItem_Column{
 					Column: &Ydb.Column{
 						Name: "int32",
-						Type: common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+						Type: Optional(Primitive(Ydb.Type_INT32)),
 					},
 				},
 			},
@@ -117,16 +117,14 @@ func (s *Suite) TestPushdownComparisonEQ() {
 	s.SetDefaultOptions()
 
 	testcases := map[string]*Ydb.TypedValue{
-		"_id":     common.MakeTypedValue(common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)), int32(0)),
-		"int32":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
-		"int64":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT64), int64(23423)),
-		"string":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "outer"),
-		"binary":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), []byte{0xab, 0xcd}),
-		"double":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_DOUBLE), float64(1.1)),
-		"boolean": common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_BOOL), false),
-		"objectid": common.MakeTypedValue(
-			common.MakeTaggedType("ObjectId",
-				common.MakePrimitiveType(Ydb.Type_STRING)),
+		"_id":     common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(0)),
+		"int32":   common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(64)),
+		"int64":   common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT64)), int64(23423)),
+		"string":  common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "outer"),
+		"binary":  common.MakeTypedValue(Optional(Primitive(Ydb.Type_STRING)), []byte{0xab, 0xcd}),
+		"double":  common.MakeTypedValue(Optional(Primitive(Ydb.Type_DOUBLE)), float64(1.1)),
+		"boolean": common.MakeTypedValue(Optional(Primitive(Ydb.Type_BOOL)), false),
+		"objectid": common.MakeTypedValue(Optional(Tagged("ObjectId", Primitive(Ydb.Type_STRING))),
 			[]byte{0x17, 0x1e, 0x75, 0x50, 0x0e, 0xcd, 0xe1, 0xc7, 0x5c, 0x59, 0x13, 0x9e},
 		),
 	}
@@ -150,7 +148,7 @@ func (s *Suite) TestPushdownStringComparison() {
 	s.SetDefaultOptions()
 
 	fieldName := "a"
-	value := common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "abc")
+	value := common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "abc")
 
 	testCases := map[string]*api_service_protos.TPredicate_Comparison{
 		"strcomp_0": tests_utils.MakePredicateComparisonColumn(
@@ -216,14 +214,14 @@ func (s *Suite) TestPushdownConjunction() {
 							Payload: tests_utils.MakePredicateComparisonColumn(
 								"a",
 								api_service_protos.TPredicate_TComparison_EQ,
-								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(1)),
+								common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(1)),
 							),
 						},
 						{
 							Payload: tests_utils.MakePredicateComparisonColumn(
 								"b",
 								api_service_protos.TPredicate_TComparison_EQ,
-								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hello"),
+								common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "hello"),
 							),
 						},
 					},
@@ -247,14 +245,14 @@ func (s *Suite) TestPushdownDisjunction() {
 							Payload: tests_utils.MakePredicateComparisonColumn(
 								"_id",
 								api_service_protos.TPredicate_TComparison_EQ,
-								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(0)),
+								common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(0)),
 							),
 						},
 						{
 							Payload: tests_utils.MakePredicateComparisonColumn(
 								"b",
 								api_service_protos.TPredicate_TComparison_EQ,
-								common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hi"),
+								common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "hi"),
 							),
 						},
 					},
@@ -277,14 +275,14 @@ func (s *Suite) TestPushdownNegation() {
 			Payload: tests_utils.MakePredicateComparisonColumn(
 				"_id",
 				api_service_protos.TPredicate_TComparison_EQ,
-				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(0)),
+				common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(0)),
 			),
 		},
 		{
 			Payload: tests_utils.MakePredicateComparisonColumn(
 				"int32",
 				api_service_protos.TPredicate_TComparison_GE,
-				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
+				common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(64)),
 			),
 		},
 	}
@@ -325,8 +323,8 @@ func (s *Suite) TestPushdownBetween() {
 		suite.WithPredicate(&api_service_protos.TPredicate{
 			Payload: tests_utils.MakePredicateBetweenColumn(
 				"_id",
-				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(2)),
-				common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(4)),
+				common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(2)),
+				common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(4)),
 			),
 		}),
 	)
@@ -337,14 +335,14 @@ func (s *Suite) TestPushdownIn() {
 
 	testCases := map[string][]*Ydb.TypedValue{
 		"_id": {
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(1)),
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(4)),
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(6)),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(1)),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(4)),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(6)),
 		},
 		"b": {
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "hi"),
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "two"),
-			common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "four"),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "hi"),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "two"),
+			common.MakeTypedValue(Optional(Primitive(Ydb.Type_UTF8)), "four"),
 		},
 	}
 
@@ -396,7 +394,7 @@ func (s *Suite) TestPushdownWithCoalesce() {
 							},
 							{
 								Payload: &api_service_protos.TExpression_TypedValue{
-									TypedValue: common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(12)),
+									TypedValue: common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(12)),
 								},
 							},
 						},
@@ -406,7 +404,7 @@ func (s *Suite) TestPushdownWithCoalesce() {
 			Operation: api_service_protos.TPredicate_TComparison_L,
 			RightValue: &api_service_protos.TExpression{
 				Payload: &api_service_protos.TExpression_TypedValue{
-					TypedValue: common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(60)),
+					TypedValue: common.MakeTypedValue(Optional(Primitive(Ydb.Type_INT32)), int32(60)),
 				},
 			},
 		},

--- a/tests/infra/datasource/mongodb/suite.go
+++ b/tests/infra/datasource/mongodb/suite.go
@@ -120,7 +120,7 @@ func (s *Suite) TestPushdownComparisonEQ() {
 		"_id":     common.MakeTypedValue(common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)), int32(0)),
 		"int32":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT32), int32(64)),
 		"int64":   common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_INT64), int64(23423)),
-		"string":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), "outer"),
+		"string":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "outer"),
 		"binary":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_STRING), []byte{0xab, 0xcd}),
 		"double":  common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_DOUBLE), float64(1.1)),
 		"boolean": common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_BOOL), false),
@@ -141,6 +141,41 @@ func (s *Suite) TestPushdownComparisonEQ() {
 					api_service_protos.TPredicate_TComparison_EQ,
 					value,
 				),
+			}),
+		)
+	}
+}
+
+func (s *Suite) TestPushdownStringComparison() {
+	s.SetDefaultOptions()
+
+	fieldName := "a"
+	value := common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), "abc")
+
+	testCases := map[string]*api_service_protos.TPredicate_Comparison{
+		"strcomp_0": tests_utils.MakePredicateComparisonColumn(
+			fieldName,
+			api_service_protos.TPredicate_TComparison_STARTS_WITH,
+			value,
+		),
+		"strcomp_1": tests_utils.MakePredicateComparisonColumn(
+			fieldName,
+			api_service_protos.TPredicate_TComparison_ENDS_WITH,
+			value,
+		),
+		"strcomp": tests_utils.MakePredicateComparisonColumn(
+			fieldName,
+			api_service_protos.TPredicate_TComparison_CONTAINS,
+			value,
+		),
+	}
+
+	for table, predicate := range testCases {
+		s.ValidateTable(
+			s.dataSource,
+			tables[table],
+			suite.WithPredicate(&api_service_protos.TPredicate{
+				Payload: predicate,
 			}),
 		)
 	}

--- a/tests/infra/datasource/mongodb/tables.go
+++ b/tests/infra/datasource/mongodb/tables.go
@@ -13,8 +13,8 @@ import (
 
 var memPool memory.Allocator = memory.NewGoAllocator()
 
-var testIdType = common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32))
-var objectIdType = common.MakeTaggedType("ObjectId", common.MakePrimitiveType(Ydb.Type_STRING))
+var testIdType = Optional(Primitive(Ydb.Type_INT32))
+var objectIdType = Tagged("ObjectId", Primitive(Ydb.Type_STRING))
 
 var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 	"simple": {
@@ -23,9 +23,9 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"c":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
+				"b":   Optional(Primitive(Ydb.Type_INT32)),
+				"c":   Optional(Primitive(Ydb.Type_INT64)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -43,9 +43,9 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"c":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
+				"b":   Optional(Primitive(Ydb.Type_INT32)),
+				"c":   Optional(Primitive(Ydb.Type_INT64)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -63,13 +63,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -95,13 +95,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -123,11 +123,11 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"c":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"d":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"e":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
+				"c":   Optional(Primitive(Ydb.Type_UTF8)),
+				"d":   Optional(Primitive(Ydb.Type_UTF8)),
+				"e":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -147,7 +147,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":     testIdType,
-				"decimal": common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"decimal": Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -163,13 +163,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -185,13 +185,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -213,13 +213,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -241,13 +241,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -269,13 +269,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id":      testIdType,
-				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
-				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
-				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
-				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
-				"objectid": common.MakeOptionalType(objectIdType),
+				"int32":    Optional(Primitive(Ydb.Type_INT32)),
+				"int64":    Optional(Primitive(Ydb.Type_INT64)),
+				"string":   Optional(Primitive(Ydb.Type_UTF8)),
+				"double":   Optional(Primitive(Ydb.Type_DOUBLE)),
+				"boolean":  Optional(Primitive(Ydb.Type_BOOL)),
+				"binary":   Optional(Primitive(Ydb.Type_STRING)),
+				"objectid": Optional(objectIdType),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -297,8 +297,8 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_INT32)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -315,8 +315,8 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_INT32)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -333,8 +333,8 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_INT32)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -351,8 +351,8 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_INT32)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -369,8 +369,8 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
-				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_INT32)),
+				"b":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -387,7 +387,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -403,7 +403,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -419,7 +419,7 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Schema: &test_utils.TableSchema{
 			Columns: map[string]*Ydb.Type{
 				"_id": testIdType,
-				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"a":   Optional(Primitive(Ydb.Type_UTF8)),
 			},
 		},
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
@@ -435,4 +435,16 @@ func newInt32IDArrayBuilder(pool memory.Allocator) func() *array.Int32Builder {
 	return func() *array.Int32Builder {
 		return array.NewInt32Builder(pool)
 	}
+}
+
+func Optional(ydbType *Ydb.Type) *Ydb.Type {
+	return common.MakeOptionalType(ydbType)
+}
+
+func Primitive(typeId Ydb.Type_PrimitiveTypeId) *Ydb.Type {
+	return common.MakePrimitiveType(typeId)
+}
+
+func Tagged(tag string, ydbType *Ydb.Type) *Ydb.Type {
+	return common.MakeTaggedType(tag, ydbType)
 }

--- a/tests/infra/datasource/mongodb/tables.go
+++ b/tests/infra/datasource/mongodb/tables.go
@@ -37,6 +37,26 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 			},
 		}},
 	},
+	"simple_last": {
+		Name:                  "simple",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"c":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(2)},
+				"a":   []*string{ptr.String("toast")},
+				"b":   []*int32{ptr.Int32(2076)},
+				"c":   []*int64{ptr.Int64(2076)},
+			},
+		}},
+	},
 	"primitives": {
 		Name:                  "primitives",
 		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
@@ -87,13 +107,13 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
 			Columns: map[string]any{
 				"_id":      []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
-				"int32":    []*int32{ptr.Int32(32), ptr.Int32(64), nil},
+				"int32":    []*int32{ptr.Int32(64), ptr.Int32(32), nil},
 				"int64":    []*int64{ptr.Int64(23423), nil, nil},
 				"string":   []*string{ptr.String("outer"), nil, nil},
 				"double":   []*float64{ptr.Float64(1.1), ptr.Float64(1.2), nil},
 				"boolean":  []*uint8{ptr.Uint8(0), ptr.Uint8(1), nil},
-				"binary":   []*[]byte{nil, ptr.T([]byte{0xab, 0xcd}), nil},
-				"objectid": []*[]byte{nil, ptr.T([]byte(string("171e75500ecde1c75c59139e"))), nil},
+				"binary":   []*[]byte{ptr.T([]byte{0xab, 0xcd}), nil, nil},
+				"objectid": []*[]byte{ptr.T([]byte(string("171e75500ecde1c75c59139e"))), nil, nil},
 			},
 		}},
 	},
@@ -121,31 +141,6 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 			},
 		}},
 	},
-	"nested": {
-		Name:                  "nested",
-		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
-		Schema: &test_utils.TableSchema{
-			Columns: map[string]*Ydb.Type{
-				"_id":    testIdType,
-				"arr":    common.MakeOptionalType(common.MakeListType(common.MakePrimitiveType(Ydb.Type_INT32))),
-				"struct": common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_JSON)),
-				"nested": common.MakeOptionalType(common.MakeListType(common.MakePrimitiveType(Ydb.Type_JSON))),
-			},
-		},
-		Records: []*test_utils.Record[int32, *array.Int32Builder]{},
-	},
-	"datetime": {
-		Name:                  "datetime",
-		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
-		Schema: &test_utils.TableSchema{
-			Columns: map[string]*Ydb.Type{
-				"_id":     testIdType,
-				"date":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INTERVAL)),
-				"datestr": common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
-			},
-		},
-		Records: []*test_utils.Record[int32, *array.Int32Builder]{},
-	},
 	"unsupported": {
 		Name:                  "unsupported",
 		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
@@ -159,6 +154,230 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 			Columns: map[string]any{
 				"_id":     []*int32{ptr.Int32(2202)},
 				"decimal": []*string{ptr.String("9823.1297")},
+			},
+		}},
+	},
+	"primitives_int32": {
+		Name:                  "primitives",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id":      testIdType,
+				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
+				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
+				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
+				"objectid": common.MakeOptionalType(objectIdType),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id":   []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
+				"int32": []*int32{ptr.Int32(42), ptr.Int32(13), ptr.Int32(15)},
+			},
+		}},
+	},
+	"missing_0": {
+		Name:                  "missing",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id":      testIdType,
+				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
+				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
+				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
+				"objectid": common.MakeOptionalType(objectIdType),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id":      []*int32{ptr.Int32(0)},
+				"int32":    []*int32{ptr.Int32(64)},
+				"int64":    []*int64{ptr.Int64(23423)},
+				"string":   []*string{ptr.String("outer")},
+				"double":   []*float64{ptr.Float64(1.1)},
+				"boolean":  []*uint8{ptr.Uint8(0)},
+				"binary":   []*[]byte{ptr.T([]byte{0xab, 0xcd})},
+				"objectid": []*[]byte{ptr.T([]byte(string("171e75500ecde1c75c59139e")))},
+			},
+		}},
+	},
+	"missing_1": {
+		Name:                  "missing",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id":      testIdType,
+				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
+				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
+				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
+				"objectid": common.MakeOptionalType(objectIdType),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id":      []*int32{ptr.Int32(1)},
+				"int32":    []*int32{ptr.Int32(32)},
+				"int64":    []*int64{nil},
+				"string":   []*string{nil},
+				"double":   []*float64{ptr.Float64(1.2)},
+				"boolean":  []*uint8{ptr.Uint8(1)},
+				"binary":   []*[]byte{nil},
+				"objectid": []*[]byte{nil},
+			},
+		}},
+	},
+	"missing_2": {
+		Name:                  "missing",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id":      testIdType,
+				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
+				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
+				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
+				"objectid": common.MakeOptionalType(objectIdType),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id":      []*int32{ptr.Int32(2)},
+				"int32":    []*int32{nil},
+				"int64":    []*int64{nil},
+				"string":   []*string{nil},
+				"double":   []*float64{nil},
+				"boolean":  []*uint8{nil},
+				"binary":   []*[]byte{nil},
+				"objectid": []*[]byte{nil},
+			},
+		}},
+	},
+	"missing_12": {
+		Name:                  "missing",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id":      testIdType,
+				"int32":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"int64":    common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT64)),
+				"string":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+				"double":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_DOUBLE)),
+				"boolean":  common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_BOOL)),
+				"binary":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_STRING)),
+				"objectid": common.MakeOptionalType(objectIdType),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id":      []*int32{ptr.Int32(1), ptr.Int32(2)},
+				"int32":    []*int32{ptr.Int32(32), nil},
+				"int64":    []*int64{nil, nil},
+				"string":   []*string{nil, nil},
+				"double":   []*float64{ptr.Float64(1.2), nil},
+				"boolean":  []*uint8{ptr.Uint8(1), nil},
+				"binary":   []*[]byte{nil, nil},
+				"objectid": []*[]byte{nil, nil},
+			},
+		}},
+	},
+	"similar_0": {
+		Name:                  "similar",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(0)},
+				"a":   []*int32{ptr.Int32(1)},
+				"b":   []*string{ptr.String("hello")},
+			},
+		}},
+	},
+	"similar_01": {
+		Name:                  "similar",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(0), ptr.Int32(1)},
+				"a":   []*int32{ptr.Int32(1), ptr.Int32(1)},
+				"b":   []*string{ptr.String("hello"), ptr.String("hi")},
+			},
+		}},
+	},
+	"similar_234": {
+		Name:                  "similar",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(2), ptr.Int32(3), ptr.Int32(4)},
+				"a":   []*int32{ptr.Int32(2), ptr.Int32(2), ptr.Int32(2)},
+				"b":   []*string{ptr.String("hello"), ptr.String("one"), ptr.String("two")},
+			},
+		}},
+	},
+	"similar_146": {
+		Name:                  "similar",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(1), ptr.Int32(4), ptr.Int32(6)},
+				"a":   []*int32{ptr.Int32(1), ptr.Int32(2), ptr.Int32(9)},
+				"b":   []*string{ptr.String("hi"), ptr.String("two"), ptr.String("four")},
+			},
+		}},
+	},
+	"similar_056": {
+		Name:                  "similar",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_INT32)),
+				"b":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(0), ptr.Int32(5), ptr.Int32(6)},
+				"a":   []*int32{ptr.Int32(1), ptr.Int32(6), ptr.Int32(9)},
+				"b":   []*string{ptr.String("hello"), ptr.String("three"), ptr.String("four")},
 			},
 		}},
 	},

--- a/tests/infra/datasource/mongodb/tables.go
+++ b/tests/infra/datasource/mongodb/tables.go
@@ -381,6 +381,54 @@ var tables = map[string]*test_utils.Table[int32, *array.Int32Builder]{
 			},
 		}},
 	},
+	"strcomp": {
+		Name:                  "strcomp",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(0), ptr.Int32(1), ptr.Int32(2)},
+				"a":   []*string{ptr.String("abc__"), ptr.String("__abc"), ptr.String("__abc__")},
+			},
+		}},
+	},
+	"strcomp_0": {
+		Name:                  "strcomp",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(0)},
+				"a":   []*string{ptr.String("abc__")},
+			},
+		}},
+	},
+	"strcomp_1": {
+		Name:                  "strcomp",
+		IDArrayBuilderFactory: newInt32IDArrayBuilder(memPool),
+		Schema: &test_utils.TableSchema{
+			Columns: map[string]*Ydb.Type{
+				"_id": testIdType,
+				"a":   common.MakeOptionalType(common.MakePrimitiveType(Ydb.Type_UTF8)),
+			},
+		},
+		Records: []*test_utils.Record[int32, *array.Int32Builder]{{
+			Columns: map[string]any{
+				"_id": []*int32{ptr.Int32(1)},
+				"a":   []*string{ptr.String("__abc")},
+			},
+		}},
+	},
 }
 
 func newInt32IDArrayBuilder(pool memory.Allocator) func() *array.Int32Builder {

--- a/tests/suite/suite.go
+++ b/tests/suite/suite.go
@@ -95,6 +95,7 @@ func (b *Base[_, _]) TearDownSuite() {
 
 type validateTableOptions struct {
 	typeMappingSettings *api_service_protos.TTypeMappingSettings
+	what                *api_service_protos.TSelect_TWhat
 	predicate           *api_service_protos.TPredicate
 	filtering           api_service_protos.TReadSplitsRequest_EFiltering
 }
@@ -141,6 +142,18 @@ type withPredicateOption struct {
 
 func (o withPredicateOption) apply(options *validateTableOptions) {
 	options.predicate = o.val
+}
+
+func WithWhat(val *api_service_protos.TSelect_TWhat) ValidateTableOption {
+	return withWhatOption{val: val}
+}
+
+type withWhatOption struct {
+	val *api_service_protos.TSelect_TWhat
+}
+
+func (o withWhatOption) apply(options *validateTableOptions) {
+	options.what = o.val
 }
 
 func WithPredicate(val *api_service_protos.TPredicate) ValidateTableOption {
@@ -219,9 +232,14 @@ func (b *Base[ID, IDBUILDER]) doValidateTable(
 	table.MatchSchema(b.T(), schema)
 
 	// list splits
+	what := common.SchemaToSelectWhatItems(schema, nil)
+	if options.what != nil {
+		what = options.what
+	}
+
 	slct := &api_service_protos.TSelect{
 		DataSourceInstance: dsi,
-		What:               common.SchemaToSelectWhatItems(schema, nil),
+		What:               what,
 		From: &api_service_protos.TSelect_TFrom{
 			Table: table.Name,
 		},

--- a/tests/utils/predicate.go
+++ b/tests/utils/predicate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 
 	api_service_protos "github.com/ydb-platform/fq-connector-go/api/service/protos"
+	"github.com/ydb-platform/fq-connector-go/common"
 )
 
 func MakePredicateComparisonColumn(
@@ -43,5 +44,80 @@ func MakePredicateIsNotNullColumn(columnName string) *api_service_protos.TPredic
 				Column: columnName,
 			},
 		}},
+	}
+}
+
+func MakePredicateBoolExpressionColumn(columnName string) *api_service_protos.TPredicate_BoolExpression {
+	return &api_service_protos.TPredicate_BoolExpression{
+		BoolExpression: &api_service_protos.TPredicate_TBoolExpression{
+			Value: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_Column{
+					Column: columnName,
+				},
+			},
+		},
+	}
+}
+
+func MakePredicateBetweenColumn(columnName string, least, greatest *Ydb.TypedValue) *api_service_protos.TPredicate_Between {
+	return &api_service_protos.TPredicate_Between{
+		Between: &api_service_protos.TPredicate_TBetween{
+			Value: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_Column{
+					Column: columnName,
+				},
+			},
+			Least: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_TypedValue{
+					TypedValue: least,
+				},
+			},
+			Greatest: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_TypedValue{
+					TypedValue: greatest,
+				},
+			},
+		},
+	}
+}
+
+func MakePredicateInColumn(columnName string, values []*Ydb.TypedValue) *api_service_protos.TPredicate_In {
+	set := make([]*api_service_protos.TExpression, 0, len(values))
+	for _, value := range values {
+		set = append(set,
+			&api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_TypedValue{
+					TypedValue: value,
+				},
+			},
+		)
+	}
+
+	return &api_service_protos.TPredicate_In{
+		In: &api_service_protos.TPredicate_TIn{
+			Value: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_Column{
+					Column: columnName,
+				},
+			},
+			Set: set,
+		},
+	}
+}
+
+func MakePredicateRegexpColumn(columnName, pattern string) *api_service_protos.TPredicate_Regexp {
+	return &api_service_protos.TPredicate_Regexp{
+		Regexp: &api_service_protos.TPredicate_TRegexp{
+			Value: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_Column{
+					Column: columnName,
+				},
+			},
+			Pattern: &api_service_protos.TExpression{
+				Payload: &api_service_protos.TExpression_TypedValue{
+					TypedValue: common.MakeTypedValue(common.MakePrimitiveType(Ydb.Type_UTF8), pattern),
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
В PR добавила поддержку:
- Проекции
- Сравнения с NULL: IsNull / IsNotNull
- Логических операторов сравнения: Comparison EQ, LE, L, GE, G, NE
- Операторов сравнения строк: Comparison ENDS_WITH, STARTS_WITH, CONTAINS
- Логического отрицания: Negation
- Конъюнкции
- Дизъюнкции
- Предиката в виде логического выражения (BoolExpression)
- Предиката наличия значения в множестве (In)
- Предиката нахождения значения в интервале (Between)
- Предиката соответствия значения регулярному выражению (Regexp)
- Выражения Coalesce